### PR TITLE
fix: remove redundant environment variables for site URL resolution

### DIFF
--- a/scripts/generate-rss.mjs
+++ b/scripts/generate-rss.mjs
@@ -17,10 +17,6 @@ const DEFAULT_SITE_URL = 'https://rebecca-powell.com/';
 function resolveBaseUrl() {
   const configured =
     process.env.SITE_URL ||
-    process.env.CF_PAGES_URL ||
-    process.env.DEPLOY_URL ||
-    process.env.DEPLOY_PRIME_URL ||
-    process.env.URL ||
     DEFAULT_SITE_URL;
 
   return new URL(configured).origin;


### PR DESCRIPTION
## Description

RSS feed with SSG defaults to preview absolute URL's before being promoted to PROD. 

## Types of changes

<!-- What types of changes does your code introduce to AstroPaper? Put an `x` in the boxes that apply -->

- [X] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Others (any other types not listed above)

## Checklist

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. You can also fill these out after creating the PR. This is simply a reminder of what we are going to look for before merging your code. -->

- [X] I have read the [Contributing Guide](https://github.com/satnaing/astro-paper/blob/main/.github/CONTRIBUTING.md)
- [ ] I have added the necessary documentation (if appropriate)
- [ ] Breaking Change (fix or feature that would cause existing functionality to not work as expected)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

## Related Issue

<!-- If this PR is related to an existing issue, link to it here. -->

Closes: #<!-- Issue number, if applicable -->
