### PR TITLE
Convert durable execution post to interactive MDX

### DIFF
--- a/src/components/DurableExecutionSimulator.tsx
+++ b/src/components/DurableExecutionSimulator.tsx
@@ -1,194 +1,407 @@
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 
-type FailurePoint = "none" | "invoice-call" | "after-payment";
-type Mode = "call" | "durable";
+type ScenarioId = "pod-restart" | "service-outage";
+type LaneId = "plain" | "durable";
+type NodeState =
+  | "idle"
+  | "running"
+  | "done"
+  | "failed"
+  | "waiting"
+  | "recovered";
 
-type Step = {
+type WorkflowStep = {
+  id: string;
   label: string;
-  callRetry: string;
-  durable: string;
+  detail: string;
 };
 
-const steps: Step[] = [
+type Scenario = {
+  id: ScenarioId;
+  label: string;
+  headline: string;
+  failureTick: number;
+  recoveryTick: number;
+  failureStep: number;
+  plainFailure: string;
+  durableRecovery: string;
+};
+
+const workflowSteps: WorkflowStep[] = [
   {
+    id: "receive",
     label: "Receive order",
-    callRetry: "The worker holds the process in memory.",
-    durable: "The workflow instance is recorded and can be resumed.",
+    detail: "The process starts in a worker.",
   },
   {
+    id: "payment",
     label: "Authorize payment",
-    callRetry:
-      "The payment call may be retried, but process progress is not durable.",
-    durable: "The payment step and its result become part of workflow history.",
+    detail: "The first external side effect succeeds.",
   },
   {
+    id: "invoice",
     label: "Create invoice",
-    callRetry: "A 503 can be retried while the worker is still alive.",
-    durable:
-      "The workflow knows this is the next incomplete step after recovery.",
+    detail: "The process needs the invoice service.",
   },
   {
+    id: "email",
     label: "Send confirmation",
-    callRetry:
-      "If the process vanished earlier, the retry policy cannot continue it.",
-    durable: "The recovered workflow continues only from the safe boundary.",
+    detail: "The customer-visible notification is sent.",
   },
   {
+    id: "fulfilment",
     label: "Notify fulfilment",
-    callRetry:
-      "The whole business journey is still reconstructed by application code.",
-    durable:
-      "The runtime coordinates the long-running process across failures.",
+    detail: "The order can move downstream.",
   },
 ];
 
-const failureCopy = {
-  none: {
-    label: "No failure",
-    call: "Both approaches look similar when nothing goes wrong. That is why the difference is easy to miss in happy-path diagrams.",
-    durable:
-      "Both approaches complete, but the durable workflow still leaves a recoverable history behind.",
+const scenarios: Scenario[] = [
+  {
+    id: "pod-restart",
+    label: "Pod forcibly restarted",
+    headline: "Worker memory disappears after payment is authorized.",
+    failureTick: 3,
+    recoveryTick: 5,
+    failureStep: 1,
+    plainFailure:
+      "The process was only alive in the worker. After the restart, the retry policy is gone and the system needs manual reconstruction or compensating code.",
+    durableRecovery:
+      "Workflow history says payment completed. A new worker replays the history and resumes at invoice creation instead of guessing.",
   },
-  "invoice-call": {
-    label: "Invoice API returns 503",
-    call: "Call-level resilience helps here: retry, back off, timeout, or open a circuit around the invoice operation.",
-    durable:
-      "Durable execution can also retry the activity, but the bigger value is that the process state survives outside the worker.",
+  {
+    id: "service-outage",
+    label: "Invoice API unavailable for 30 minutes",
+    headline:
+      "One dependency is down longer than a normal in-memory retry window.",
+    failureTick: 4,
+    recoveryTick: 7,
+    failureStep: 2,
+    plainFailure:
+      "The HTTP retry loop runs while the worker is alive, then gives up or loses context. The wider order process is now stuck outside the retry library.",
+    durableRecovery:
+      "The workflow records the timer and failed activity attempt, waits through the outage, then resumes automatically when the dependency recovers.",
   },
-  "after-payment": {
-    label: "Worker crashes after payment",
-    call: "The retry policy died with the worker. It cannot answer which business step already happened or what is safe to do next.",
-    durable:
-      "The workflow history says payment was authorized and invoice creation is next, so a new worker can resume safely.",
-  },
-} satisfies Record<
-  FailurePoint,
-  { label: string; call: string; durable: string }
->;
+];
 
-export default function DurableExecutionSimulator() {
-  const [mode, setMode] = useState<Mode>("durable");
-  const [failurePoint, setFailurePoint] =
-    useState<FailurePoint>("after-payment");
+const totalTicks = 11;
+const tickDurationMs = 1200;
 
-  const activeFailure = failureCopy[failurePoint];
-  const outcome = mode === "call" ? activeFailure.call : activeFailure.durable;
+function getStepState(
+  lane: LaneId,
+  stepIndex: number,
+  tick: number,
+  scenario: Scenario
+): NodeState {
+  const shiftedTick =
+    lane === "durable" && tick >= scenario.recoveryTick ? tick - 1 : tick;
 
-  const activeStepIndex = useMemo(() => {
-    if (failurePoint === "invoice-call") return 2;
-    if (failurePoint === "after-payment") return 1;
-    return steps.length - 1;
-  }, [failurePoint]);
+  if (tick < stepIndex + 1) return "idle";
+
+  if (lane === "plain" && tick >= scenario.failureTick) {
+    if (stepIndex === scenario.failureStep) return "failed";
+    if (stepIndex < scenario.failureStep) return "done";
+    return "idle";
+  }
+
+  if (lane === "durable") {
+    if (tick === scenario.failureTick && stepIndex === scenario.failureStep) {
+      return "failed";
+    }
+
+    if (
+      tick > scenario.failureTick &&
+      tick < scenario.recoveryTick &&
+      stepIndex === scenario.failureStep + 1
+    ) {
+      return "waiting";
+    }
+
+    if (
+      tick === scenario.recoveryTick &&
+      stepIndex === scenario.failureStep + 1
+    ) {
+      return "recovered";
+    }
+  }
+
+  if (shiftedTick === stepIndex + 1) return "running";
+  if (shiftedTick > stepIndex + 1) return "done";
+
+  return "idle";
+}
+
+function getLaneNarrative(lane: LaneId, tick: number, scenario: Scenario) {
+  if (tick < scenario.failureTick) {
+    return lane === "plain"
+      ? "The order is moving through ordinary process memory. Retries can protect individual calls while the worker stays alive."
+      : "The workflow records each completed step outside the worker before moving to the next activity.";
+  }
+
+  if (tick === scenario.failureTick) {
+    return lane === "plain"
+      ? scenario.plainFailure
+      : "Failure is observed, but the workflow instance and completed history still exist outside the crashed or blocked worker.";
+  }
+
+  if (tick < scenario.recoveryTick) {
+    return lane === "plain"
+      ? "Nothing is driving the business process forward now. Operators need logs, dashboards, or custom repair code to decide what happened."
+      : scenario.id === "service-outage"
+        ? "The durable runtime parks the workflow on a timer instead of burning a worker thread for the entire outage."
+        : "A replacement worker can be started without losing the workflow's place in the business process.";
+  }
+
+  if (tick === scenario.recoveryTick) {
+    return lane === "plain"
+      ? "Restarting infrastructure does not recreate the lost process state. The next safe action is ambiguous."
+      : scenario.durableRecovery;
+  }
+
+  return lane === "plain"
+    ? "The non-durable lane remains stuck at the failure boundary because call retries were not a process recovery model."
+    : "The durable lane finishes the remaining process steps from the recorded recovery point.";
+}
+
+function StatusPill({ state }: { state: NodeState }) {
+  const label = {
+    idle: "waiting",
+    running: "running",
+    done: "done",
+    failed: "failed",
+    waiting: "parked",
+    recovered: "resume",
+  }[state];
+
+  const classes = {
+    idle: "border-border bg-muted text-foreground/55",
+    running: "border-accent bg-accent/10 text-accent",
+    done: "border-emerald-500/40 bg-emerald-500/10 text-emerald-700 dark:text-emerald-300",
+    failed: "border-red-500/50 bg-red-500/10 text-red-700 dark:text-red-300",
+    waiting:
+      "border-amber-500/50 bg-amber-500/10 text-amber-700 dark:text-amber-300",
+    recovered: "border-sky-500/50 bg-sky-500/10 text-sky-700 dark:text-sky-300",
+  }[state];
 
   return (
-    <section className="not-prose my-10 overflow-hidden rounded-2xl border border-border bg-muted/40 p-5 sm:p-6">
-      <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
-        <div className="max-w-2xl">
-          <p className="text-xs font-semibold tracking-[0.2em] text-accent uppercase">
-            Interactive view
-          </p>
-          <div className="mt-1 text-xl font-semibold text-foreground">
-            Calls retry; workflows resume
-          </div>
-          <p className="mt-2 text-sm leading-6 text-foreground/80">
-            Change the failure and compare the recovery story. Retry libraries
-            protect a running call. Durable execution protects the process that
-            surrounds many calls.
-          </p>
-        </div>
+    <span
+      className={`rounded-full border px-2 py-0.5 text-[0.65rem] font-semibold tracking-wide uppercase ${classes}`}
+    >
+      {label}
+    </span>
+  );
+}
 
-        <div className="flex flex-wrap gap-2 text-sm">
-          {(["call", "durable"] as Mode[]).map(option => (
-            <button
-              key={option}
-              type="button"
-              onClick={() => setMode(option)}
-              aria-pressed={mode === option}
-              className={`rounded-md border px-3 py-1.5 transition-colors ${
-                mode === option
-                  ? "border-accent bg-accent text-background"
-                  : "border-border bg-background text-foreground hover:border-accent"
-              }`}
-            >
-              {option === "call" ? "Call retry" : "Durable workflow"}
-            </button>
-          ))}
+function WorkflowLane({
+  lane,
+  tick,
+  scenario,
+}: {
+  lane: LaneId;
+  tick: number;
+  scenario: Scenario;
+}) {
+  const laneTitle =
+    lane === "plain" ? "Without durable execution" : "With durable execution";
+  const laneSubtitle =
+    lane === "plain"
+      ? "Call retries live inside the worker."
+      : "Workflow history lives outside the worker.";
+
+  return (
+    <div className="rounded-2xl border border-border bg-background p-4 shadow-sm">
+      <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+        <div>
+          <div className="text-base font-semibold text-foreground">
+            {laneTitle}
+          </div>
+          <p className="mt-1 text-sm text-foreground/65">{laneSubtitle}</p>
         </div>
+        <StatusPill
+          state={
+            lane === "plain" && tick >= scenario.failureTick
+              ? "failed"
+              : tick >= scenario.recoveryTick
+                ? "recovered"
+                : "running"
+          }
+        />
       </div>
 
-      <div className="mt-6 grid gap-5 lg:grid-cols-[0.9fr_1.1fr]">
-        <div className="rounded-2xl border border-border bg-background p-4">
-          <div className="text-sm font-semibold text-foreground">
-            Failure to simulate
-          </div>
-          <div className="mt-3 grid gap-2">
-            {(Object.keys(failureCopy) as FailurePoint[]).map(key => (
-              <button
-                key={key}
-                type="button"
-                onClick={() => setFailurePoint(key)}
-                className={`rounded-xl border p-3 text-left text-sm transition-colors ${
-                  failurePoint === key
-                    ? "border-accent bg-accent/10 text-foreground"
-                    : "border-border text-foreground/75 hover:border-accent/70"
-                }`}
-              >
-                {failureCopy[key].label}
-              </button>
-            ))}
-          </div>
+      <div className="mt-5 grid gap-3 md:grid-cols-5">
+        {workflowSteps.map((step, index) => {
+          const state = getStepState(lane, index, tick, scenario);
+          const isActive = [
+            "running",
+            "failed",
+            "waiting",
+            "recovered",
+          ].includes(state);
 
-          <div className="mt-4 rounded-xl border border-border bg-muted/50 p-4">
-            <div className="text-xs font-semibold tracking-[0.16em] text-accent uppercase">
-              Result
-            </div>
-            <p className="mt-2 text-sm leading-6 text-foreground/85">
-              {outcome}
-            </p>
-          </div>
-        </div>
-
-        <ol className="relative grid gap-3">
-          {steps.map((step, index) => {
-            const isPast = index < activeStepIndex || failurePoint === "none";
-            const isActive =
-              index === activeStepIndex && failurePoint !== "none";
-            const body = mode === "call" ? step.callRetry : step.durable;
-
-            return (
-              <li
-                key={step.label}
-                className={`rounded-2xl border p-4 transition-colors ${
+          return (
+            <div key={step.id} className="relative">
+              {index > 0 && (
+                <div
+                  className={`absolute top-6 -left-3 hidden h-0.5 w-3 md:block ${
+                    state === "idle" ? "bg-border" : "bg-accent/60"
+                  }`}
+                />
+              )}
+              <div
+                className={`min-h-40 rounded-2xl border p-3 transition-all duration-500 ${
                   isActive
-                    ? "border-accent bg-background shadow-sm"
-                    : isPast
-                      ? "border-border bg-background/90"
-                      : "border-border bg-background/50"
+                    ? "scale-[1.02] border-accent bg-accent/10 shadow-md shadow-accent/10"
+                    : state === "done"
+                      ? "border-emerald-500/30 bg-emerald-500/5"
+                      : "border-border bg-muted/30"
                 }`}
               >
-                <div className="flex items-start gap-3">
+                <div className="flex items-center justify-between gap-2">
                   <span
-                    className={`flex h-8 w-8 shrink-0 items-center justify-center rounded-full border text-sm font-semibold ${
-                      isActive
-                        ? "border-accent bg-accent text-background"
-                        : "border-border bg-muted text-foreground/80"
+                    className={`flex h-7 w-7 items-center justify-center rounded-full text-xs font-bold ${
+                      state === "failed"
+                        ? "bg-red-500 text-white"
+                        : state === "done"
+                          ? "bg-emerald-500 text-white"
+                          : state === "waiting"
+                            ? "bg-amber-500 text-white"
+                            : state === "recovered"
+                              ? "bg-sky-500 text-white"
+                              : state === "running"
+                                ? "animate-pulse bg-accent text-background"
+                                : "bg-background text-foreground/45"
                     }`}
                   >
                     {index + 1}
                   </span>
-                  <div>
-                    <div className="font-semibold text-foreground">
-                      {step.label}
-                    </div>
-                    <p className="mt-1 text-sm leading-6 text-foreground/75">
-                      {body}
-                    </p>
-                  </div>
+                  <StatusPill state={state} />
                 </div>
-              </li>
-            );
-          })}
-        </ol>
+                <div className="mt-3 text-sm leading-5 font-semibold text-foreground">
+                  {step.label}
+                </div>
+                <p className="mt-2 text-xs leading-5 text-foreground/65">
+                  {step.detail}
+                </p>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+
+      <div className="mt-4 rounded-xl border border-border bg-muted/40 p-4">
+        <div className="text-xs font-semibold tracking-[0.16em] text-accent uppercase">
+          What happens now
+        </div>
+        <p className="mt-2 text-sm leading-6 text-foreground/80">
+          {getLaneNarrative(lane, tick, scenario)}
+        </p>
+      </div>
+    </div>
+  );
+}
+
+export default function DurableExecutionSimulator() {
+  const [scenarioId, setScenarioId] = useState<ScenarioId>("pod-restart");
+  const [tick, setTick] = useState(0);
+  const [isPlaying, setIsPlaying] = useState(true);
+
+  const scenario = useMemo(
+    () => scenarios.find(item => item.id === scenarioId) ?? scenarios[0],
+    [scenarioId]
+  );
+
+  useEffect(() => {
+    if (!isPlaying) return undefined;
+
+    const timer = window.setInterval(() => {
+      setTick(current => (current + 1) % totalTicks);
+    }, tickDurationMs);
+
+    return () => window.clearInterval(timer);
+  }, [isPlaying]);
+
+  const selectScenario = (nextScenarioId: ScenarioId) => {
+    setScenarioId(nextScenarioId);
+    setTick(0);
+    setIsPlaying(true);
+  };
+
+  return (
+    <section className="not-prose my-10 overflow-hidden rounded-2xl border border-border bg-muted/40 p-5 sm:p-6">
+      <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+        <div className="max-w-3xl">
+          <p className="text-xs font-semibold tracking-[0.2em] text-accent uppercase">
+            Animated workflow map
+          </p>
+          <div className="mt-1 text-xl font-semibold text-foreground">
+            Same failure, two execution models
+          </div>
+          <p className="mt-2 text-sm leading-6 text-foreground/80">
+            Watch the order process loop through a failure. The top-level story
+            is not whether one HTTP call can retry. It is whether the whole
+            business process has somewhere durable to live when workers restart
+            or services disappear for longer than an in-memory retry loop.
+          </p>
+        </div>
+
+        <div className="flex flex-wrap gap-2 text-sm">
+          <button
+            type="button"
+            onClick={() => setIsPlaying(current => !current)}
+            className="rounded-md border border-accent bg-accent px-3 py-1.5 text-background transition-opacity hover:opacity-90"
+          >
+            {isPlaying ? "Pause" : "Play"}
+          </button>
+          <button
+            type="button"
+            onClick={() => setTick(0)}
+            className="rounded-md border border-border px-3 py-1.5 text-foreground transition-colors hover:border-accent"
+          >
+            Restart loop
+          </button>
+        </div>
+      </div>
+
+      <div className="mt-5 flex flex-wrap gap-2 text-sm">
+        {scenarios.map(item => (
+          <button
+            key={item.id}
+            type="button"
+            onClick={() => selectScenario(item.id)}
+            aria-pressed={scenario.id === item.id}
+            className={`rounded-full border px-3 py-1.5 transition-colors ${
+              scenario.id === item.id
+                ? "border-accent bg-accent/10 text-accent"
+                : "border-border bg-background text-foreground/75 hover:border-accent/70"
+            }`}
+          >
+            {item.label}
+          </button>
+        ))}
+      </div>
+
+      <div className="mt-5 rounded-2xl border border-border bg-background/80 p-4">
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <div className="text-sm font-semibold text-foreground">
+              {scenario.headline}
+            </div>
+            <p className="mt-1 text-xs leading-5 text-foreground/60">
+              Loop frame {tick + 1} of {totalTicks}: follow the highlighted
+              cards through failure, waiting, recovery, and completion.
+            </p>
+          </div>
+          <div className="h-2 w-full overflow-hidden rounded-full bg-muted sm:max-w-56">
+            <div
+              className="h-full rounded-full bg-accent transition-all duration-500"
+              style={{ width: `${((tick + 1) / totalTicks) * 100}%` }}
+            />
+          </div>
+        </div>
+      </div>
+
+      <div className="mt-5 grid gap-5">
+        <WorkflowLane lane="plain" tick={tick} scenario={scenario} />
+        <WorkflowLane lane="durable" tick={tick} scenario={scenario} />
       </div>
     </section>
   );

--- a/src/components/DurableExecutionSimulator.tsx
+++ b/src/components/DurableExecutionSimulator.tsx
@@ -1,0 +1,195 @@
+import { useMemo, useState } from "react";
+
+type FailurePoint = "none" | "invoice-call" | "after-payment";
+type Mode = "call" | "durable";
+
+type Step = {
+  label: string;
+  callRetry: string;
+  durable: string;
+};
+
+const steps: Step[] = [
+  {
+    label: "Receive order",
+    callRetry: "The worker holds the process in memory.",
+    durable: "The workflow instance is recorded and can be resumed.",
+  },
+  {
+    label: "Authorize payment",
+    callRetry:
+      "The payment call may be retried, but process progress is not durable.",
+    durable: "The payment step and its result become part of workflow history.",
+  },
+  {
+    label: "Create invoice",
+    callRetry: "A 503 can be retried while the worker is still alive.",
+    durable:
+      "The workflow knows this is the next incomplete step after recovery.",
+  },
+  {
+    label: "Send confirmation",
+    callRetry:
+      "If the process vanished earlier, the retry policy cannot continue it.",
+    durable: "The recovered workflow continues only from the safe boundary.",
+  },
+  {
+    label: "Notify fulfilment",
+    callRetry:
+      "The whole business journey is still reconstructed by application code.",
+    durable:
+      "The runtime coordinates the long-running process across failures.",
+  },
+];
+
+const failureCopy = {
+  none: {
+    label: "No failure",
+    call: "Both approaches look similar when nothing goes wrong. That is why the difference is easy to miss in happy-path diagrams.",
+    durable:
+      "Both approaches complete, but the durable workflow still leaves a recoverable history behind.",
+  },
+  "invoice-call": {
+    label: "Invoice API returns 503",
+    call: "Call-level resilience helps here: retry, back off, timeout, or open a circuit around the invoice operation.",
+    durable:
+      "Durable execution can also retry the activity, but the bigger value is that the process state survives outside the worker.",
+  },
+  "after-payment": {
+    label: "Worker crashes after payment",
+    call: "The retry policy died with the worker. It cannot answer which business step already happened or what is safe to do next.",
+    durable:
+      "The workflow history says payment was authorized and invoice creation is next, so a new worker can resume safely.",
+  },
+} satisfies Record<
+  FailurePoint,
+  { label: string; call: string; durable: string }
+>;
+
+export default function DurableExecutionSimulator() {
+  const [mode, setMode] = useState<Mode>("durable");
+  const [failurePoint, setFailurePoint] =
+    useState<FailurePoint>("after-payment");
+
+  const activeFailure = failureCopy[failurePoint];
+  const outcome = mode === "call" ? activeFailure.call : activeFailure.durable;
+
+  const activeStepIndex = useMemo(() => {
+    if (failurePoint === "invoice-call") return 2;
+    if (failurePoint === "after-payment") return 1;
+    return steps.length - 1;
+  }, [failurePoint]);
+
+  return (
+    <section className="not-prose my-10 overflow-hidden rounded-2xl border border-border bg-muted/40 p-5 sm:p-6">
+      <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+        <div className="max-w-2xl">
+          <p className="text-xs font-semibold tracking-[0.2em] text-accent uppercase">
+            Interactive view
+          </p>
+          <div className="mt-1 text-xl font-semibold text-foreground">
+            Calls retry; workflows resume
+          </div>
+          <p className="mt-2 text-sm leading-6 text-foreground/80">
+            Change the failure and compare the recovery story. Retry libraries
+            protect a running call. Durable execution protects the process that
+            surrounds many calls.
+          </p>
+        </div>
+
+        <div className="flex flex-wrap gap-2 text-sm">
+          {(["call", "durable"] as Mode[]).map(option => (
+            <button
+              key={option}
+              type="button"
+              onClick={() => setMode(option)}
+              aria-pressed={mode === option}
+              className={`rounded-md border px-3 py-1.5 transition-colors ${
+                mode === option
+                  ? "border-accent bg-accent text-background"
+                  : "border-border bg-background text-foreground hover:border-accent"
+              }`}
+            >
+              {option === "call" ? "Call retry" : "Durable workflow"}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <div className="mt-6 grid gap-5 lg:grid-cols-[0.9fr_1.1fr]">
+        <div className="rounded-2xl border border-border bg-background p-4">
+          <div className="text-sm font-semibold text-foreground">
+            Failure to simulate
+          </div>
+          <div className="mt-3 grid gap-2">
+            {(Object.keys(failureCopy) as FailurePoint[]).map(key => (
+              <button
+                key={key}
+                type="button"
+                onClick={() => setFailurePoint(key)}
+                className={`rounded-xl border p-3 text-left text-sm transition-colors ${
+                  failurePoint === key
+                    ? "border-accent bg-accent/10 text-foreground"
+                    : "border-border text-foreground/75 hover:border-accent/70"
+                }`}
+              >
+                {failureCopy[key].label}
+              </button>
+            ))}
+          </div>
+
+          <div className="mt-4 rounded-xl border border-border bg-muted/50 p-4">
+            <div className="text-xs font-semibold tracking-[0.16em] text-accent uppercase">
+              Result
+            </div>
+            <p className="mt-2 text-sm leading-6 text-foreground/85">
+              {outcome}
+            </p>
+          </div>
+        </div>
+
+        <ol className="relative grid gap-3">
+          {steps.map((step, index) => {
+            const isPast = index < activeStepIndex || failurePoint === "none";
+            const isActive =
+              index === activeStepIndex && failurePoint !== "none";
+            const body = mode === "call" ? step.callRetry : step.durable;
+
+            return (
+              <li
+                key={step.label}
+                className={`rounded-2xl border p-4 transition-colors ${
+                  isActive
+                    ? "border-accent bg-background shadow-sm"
+                    : isPast
+                      ? "border-border bg-background/90"
+                      : "border-border bg-background/50"
+                }`}
+              >
+                <div className="flex items-start gap-3">
+                  <span
+                    className={`flex h-8 w-8 shrink-0 items-center justify-center rounded-full border text-sm font-semibold ${
+                      isActive
+                        ? "border-accent bg-accent text-background"
+                        : "border-border bg-muted text-foreground/80"
+                    }`}
+                  >
+                    {index + 1}
+                  </span>
+                  <div>
+                    <div className="font-semibold text-foreground">
+                      {step.label}
+                    </div>
+                    <p className="mt-1 text-sm leading-6 text-foreground/75">
+                      {body}
+                    </p>
+                  </div>
+                </div>
+              </li>
+            );
+          })}
+        </ol>
+      </div>
+    </section>
+  );
+}

--- a/src/components/WowlActivityDesigner.tsx
+++ b/src/components/WowlActivityDesigner.tsx
@@ -1,0 +1,151 @@
+import { useMemo, useState } from "react";
+
+type Operation = {
+  id: string;
+  label: string;
+  kind: "read" | "compute" | "write";
+  system?: string;
+};
+
+const operations: Operation[] = [
+  { id: "read-order", label: "Read order", kind: "read" },
+  { id: "read-customer", label: "Read customer", kind: "read" },
+  { id: "calculate", label: "Calculate totals", kind: "compute" },
+  { id: "charge", label: "Charge payment", kind: "write", system: "Gateway" },
+  { id: "crm", label: "Update CRM", kind: "write", system: "CRM" },
+  { id: "email", label: "Send email", kind: "write", system: "Email" },
+  { id: "event", label: "Publish event", kind: "write", system: "Broker" },
+];
+
+const safeDefault = ["read-order", "read-customer", "calculate", "charge"];
+const sprayDefault = operations.map(operation => operation.id);
+
+export default function WowlActivityDesigner() {
+  const [selectedIds, setSelectedIds] = useState<string[]>(sprayDefault);
+
+  const selectedOperations = useMemo(
+    () => operations.filter(operation => selectedIds.includes(operation.id)),
+    [selectedIds]
+  );
+
+  const writeCount = selectedOperations.filter(
+    operation => operation.kind === "write"
+  ).length;
+  const lastOperation = selectedOperations.at(-1);
+  const writeLast = lastOperation?.kind === "write";
+  const safeShape = writeCount <= 1 && writeLast;
+
+  const toggleOperation = (operationId: string) => {
+    setSelectedIds(current =>
+      current.includes(operationId)
+        ? current.filter(id => id !== operationId)
+        : [...current, operationId]
+    );
+  };
+
+  return (
+    <section className="not-prose my-10 rounded-2xl border border-border bg-muted/40 p-5 sm:p-6">
+      <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+        <div className="max-w-2xl">
+          <p className="text-xs font-semibold tracking-[0.2em] text-accent uppercase">
+            Interactive checklist
+          </p>
+          <div className="mt-1 text-xl font-semibold text-foreground">
+            WOWL activity designer
+          </div>
+          <p className="mt-2 text-sm leading-6 text-foreground/80">
+            Toggle what one retryable activity does. The safer shape is
+            repeatable work first, then one controlled external write at the
+            end.
+          </p>
+        </div>
+        <div className="flex flex-wrap gap-2 text-sm">
+          <button
+            type="button"
+            onClick={() => setSelectedIds(safeDefault)}
+            className="rounded-md border border-accent bg-accent px-3 py-1.5 text-background"
+          >
+            Show WOWL shape
+          </button>
+          <button
+            type="button"
+            onClick={() => setSelectedIds(sprayDefault)}
+            className="rounded-md border border-border px-3 py-1.5 text-foreground hover:border-accent"
+          >
+            Show spray writes
+          </button>
+        </div>
+      </div>
+
+      <div className="mt-6 grid gap-5 lg:grid-cols-[1fr_1fr]">
+        <div className="grid gap-2">
+          {operations.map(operation => {
+            const isSelected = selectedIds.includes(operation.id);
+            return (
+              <button
+                key={operation.id}
+                type="button"
+                onClick={() => toggleOperation(operation.id)}
+                aria-pressed={isSelected}
+                className={`flex items-center justify-between gap-3 rounded-xl border p-3 text-left transition-colors ${
+                  isSelected
+                    ? "border-accent bg-background"
+                    : "border-border bg-background/60 opacity-70"
+                }`}
+              >
+                <span>
+                  <span className="block text-sm font-semibold text-foreground">
+                    {operation.label}
+                  </span>
+                  <span className="text-xs text-foreground/60">
+                    {operation.kind === "write"
+                      ? `External write${operation.system ? `: ${operation.system}` : ""}`
+                      : "Repeatable before the boundary"}
+                  </span>
+                </span>
+                <span
+                  className={`rounded-full px-2 py-1 text-xs font-semibold ${operation.kind === "write" ? "bg-accent/15 text-accent" : "bg-muted text-foreground/70"}`}
+                >
+                  {operation.kind}
+                </span>
+              </button>
+            );
+          })}
+        </div>
+
+        <div className="rounded-2xl border border-border bg-background p-4">
+          <div className="text-sm font-semibold text-foreground">
+            Retry boundary
+          </div>
+          <div className="mt-4 flex flex-wrap items-center gap-2">
+            {selectedOperations.map((operation, index) => (
+              <div key={operation.id} className="flex items-center gap-2">
+                <span
+                  className={`rounded-full border px-3 py-1.5 text-sm ${operation.kind === "write" ? "border-accent bg-accent/10 text-accent" : "border-border bg-muted text-foreground/75"}`}
+                >
+                  {operation.label}
+                </span>
+                {index < selectedOperations.length - 1 && (
+                  <span className="text-foreground/35">→</span>
+                )}
+              </div>
+            ))}
+          </div>
+
+          <div
+            className={`mt-5 rounded-xl border p-4 ${safeShape ? "border-accent bg-accent/10" : "border-border bg-muted/60"}`}
+          >
+            <div className="text-base font-semibold text-foreground">
+              {safeShape ? "WOWL-friendly" : "Recovery smell"}
+            </div>
+            <p className="mt-2 text-sm leading-6 text-foreground/80">
+              {safeShape
+                ? "This activity reads, calculates, and performs one externally visible write last. If it retries, the side-effect question is narrow."
+                : `This retry boundary contains ${writeCount} external writes. If it crashes halfway through, recovery depends on every write being idempotent or deduplicated.`}
+            </p>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/data/blog/2026-06-20-durable-execution-wowl.mdx
+++ b/src/data/blog/2026-06-20-durable-execution-wowl.mdx
@@ -14,6 +14,9 @@ tags:
   - architecture
 ---
 
+import DurableExecutionSimulator from "@/components/DurableExecutionSimulator";
+import WowlActivityDesigner from "@/components/WowlActivityDesigner";
+
 ![Retries are not durable execution](/assets/posts/durable-execution-wowl/01-retries-are-not-durable-execution.jpg)
 
 Retries are not durable execution.
@@ -34,6 +37,8 @@ But those tools usually sit around a **call**.
 Durable execution sits around a **process**.
 
 That is the abstraction shift.
+
+<DurableExecutionSimulator client:visible />
 
 ![The difference is the abstraction layer](/assets/posts/durable-execution-wowl/02-abstraction-layer.jpg)
 
@@ -209,6 +214,8 @@ But if your activity performs four different external writes and then crashes ha
 That is where my own shorthand comes in:
 
 > **WOWL: Write Once, Write Last**
+
+<WowlActivityDesigner client:visible />
 
 ## WOWL: Write Once, Write Last
 


### PR DESCRIPTION
### Motivation
- Migrate the static Markdown post to MDX so interactive React components can be embedded to better illustrate durable-execution concepts. 
- Provide runnable, visual aids to demonstrate the distinction between call-level retries and durable workflows and to teach the WOWL (Write Once, Write Last) design rule.

### Description
- Renamed the post from `src/data/blog/2026-06-20-durable-execution-wowl.md` to `src/data/blog/2026-06-20-durable-execution-wowl.mdx` and imported two new components into the post. 
- Added `src/components/DurableExecutionSimulator.tsx`, a client-side React component that simulates failure scenarios and compares `Call retry` vs `Durable workflow` recovery stories. 
- Added `src/components/WowlActivityDesigner.tsx`, a client-side React checklist that lets readers toggle operations to visualise WOWL-friendly shapes versus “spray writes” recovery smells. 
- Embedded both components into the post using `client:visible` and applied site theme classes so they render within the existing layout and style system. 

### Testing
- Ran `npx astro check` and the type/content checks completed with no errors. 
- Ran `npm run lint` and `prettier` formatting on the new files and they succeeded. 
- Attempted `npm run build`; Astro and Vite completed but static route generation failed while generating the OG image because the build could not fetch the remote Google font, causing the build step to abort. 
- Attempted Playwright-driven interaction testing and `npx playwright install chromium`, but the Playwright browser download failed with a `403 Domain forbidden` from the CDN, preventing automated screenshot verification.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a370c7edfbc832ba51b3f874f1aaebf)